### PR TITLE
Patch for Fixed header and/or scrollX DT

### DIFF
--- a/js/dataTables.autoFill.js
+++ b/js/dataTables.autoFill.js
@@ -192,6 +192,7 @@ $.extend( AutoFill.prototype, {
 		var idx = dt.cell( node ).index();
 		var handle = this.dom.handle;
 		var handleDim = this.s.handle;
+		var dtScroll = $('div.dataTables_scrollBody', this.s.dt.table().container() );
 
 		if ( ! idx || dt.columns( this.c.columns ).indexes().indexOf( idx.column ) === -1 ) {
 			this._detach();
@@ -215,8 +216,8 @@ $.extend( AutoFill.prototype, {
 		this.dom.attachedTo = node;
 		handle
 			.css( {
-				top: offset.top + node.offsetHeight - handleDim.height,
-				left: offset.left + node.offsetWidth - handleDim.width
+				top: offset.top + node.offsetHeight - handleDim.height + dtScroll.scrollTop(),
+				left: offset.left + node.offsetWidth - handleDim.width + dtScroll.scrollLeft()
 			} )
 			.appendTo( this.dom.offsetParent );
 	},
@@ -642,6 +643,10 @@ $.extend( AutoFill.prototype, {
 		}
 
 		this._actionSelector( selected );
+		
+		// Stop shiftScroll
+		clearInterval( this.s.scrollInterval );
+		this.s.scrollInterval = null;
 	},
 
 


### PR DESCRIPTION
Hi,
I identified 2 things and fixed them : 

Context : I used AutoFill on huge table with fixed header (and columns) and no paging.
- Firstable, after scrolling on DT, $('.dt-autofill-handle') div wasn't anymore hover the right cell
- Secondable if the mouseOut event was during shiftScroll, the shiftScroll continued (even after the AutoFill Event)

So, I updated the $('.dt-autofill-handle') positions calculation to consider the $('.dataTables_scrollBody') scroll values.
And I add a clearInterval for scrollInterval (of schiftScroll), on the MouseUp function.

I Hope that could help somebody.

Regards,
